### PR TITLE
Remove getScalingFactor from SDC interface

### DIFF
--- a/src/fsi/SDC.C
+++ b/src/fsi/SDC.C
@@ -251,7 +251,6 @@ namespace sdc
             squaredNorm[Pstream::myProcNo()] = residual.squaredNorm();
             reduce( squaredNorm, sumOp<scalarList>() );
             scalar error = std::sqrt( sum( squaredNorm ) / N );
-            error /= solver->getScalingFactor();
             bool convergence = error < tol && j >= minSweeps - 2;
 
             std::deque<int> dofVariables;

--- a/src/fsi/SDC.C
+++ b/src/fsi/SDC.C
@@ -180,7 +180,7 @@ namespace sdc
             solver->nextTimeStep();
 
         fsi::vector dtsdc = this->dt * dsdc;
-        fsi::matrix solStages( k, N ), F( k, N ), Fembedded( nodesEmbedded.rows(), N ), residual;
+        fsi::matrix solStages( k, N ), F( k, N ), Fembedded( nodesEmbedded.rows(), N ), residual, diff;
         fsi::matrix qj( 1, solStages.cols() ), qjEmbedded( 1, solStages.cols() );
         fsi::vector errorEstimate( N );
 
@@ -243,14 +243,17 @@ namespace sdc
             // Compute the SDC residual
 
             residual = dt * (qmat * F);
+            diff = residual;
 
             for ( int i = 0; i < residual.rows(); i++ )
                 residual.row( i ) += solStages.row( 0 ) - solStages.row( i + 1 );
 
-            scalarList squaredNorm( Pstream::nProcs(), scalar( 0 ) );
-            squaredNorm[Pstream::myProcNo()] = residual.squaredNorm();
-            reduce( squaredNorm, sumOp<scalarList>() );
-            scalar error = std::sqrt( sum( squaredNorm ) / N );
+            scalarList squaredNormResidual( Pstream::nProcs(), scalar( 0 ) ), squaredNormDiff( Pstream::nProcs(), scalar( 0 ) );
+            squaredNormResidual[Pstream::myProcNo()] = residual.squaredNorm();
+            squaredNormDiff[Pstream::myProcNo()] = diff.squaredNorm();
+            reduce( squaredNormResidual, sumOp<scalarList>() );
+            reduce( squaredNormDiff, sumOp<scalarList>() );
+            scalar error = std::sqrt( sum( squaredNormResidual ) / sum( squaredNormDiff ) );
             bool convergence = error < tol && j >= minSweeps - 2;
 
             std::deque<int> dofVariables;
@@ -301,19 +304,18 @@ namespace sdc
                     {
                         assert( dofVariables.at( i ) > 0 );
 
-                        scalarList squaredNorm( Pstream::nProcs(), scalar( 0 ) );
-                        labelList dofVariablesGlobal( Pstream::nProcs(), 0 );
-                        dofVariablesGlobal[Pstream::myProcNo()] = dofVariables.at( i );
-                        reduce( dofVariablesGlobal, sumOp<labelList>() );
+                        scalarList squaredNormResidual( Pstream::nProcs(), scalar( 0 ) ), squaredNormDiff( Pstream::nProcs(), scalar( 0 ) );
 
                         for ( int j = 0; j < dofVariables.at( i ); j++ )
                         {
-                            squaredNorm[Pstream::myProcNo()] += residual( substep, index ) * residual( substep, index );
+                            squaredNormResidual[Pstream::myProcNo()] += residual( substep, index ) * residual( substep, index );
+                            squaredNormDiff[Pstream::myProcNo()] += diff( substep, index ) * diff( substep, index );
                             index++;
                         }
 
-                        reduce( squaredNorm, sumOp<scalarList>() );
-                        scalar error = std::sqrt( sum( squaredNorm ) / sum( dofVariablesGlobal ) );
+                        reduce( squaredNormResidual, sumOp<scalarList>() );
+                        reduce( squaredNormDiff, sumOp<scalarList>() );
+                        scalar error = std::sqrt( sum( squaredNormResidual ) / sum( squaredNormDiff ) );
 
                         if ( error > tol || j < minSweeps - 2 )
                             convergence = false;

--- a/src/fsi/SDCFsiSolver.C
+++ b/src/fsi/SDCFsiSolver.C
@@ -60,11 +60,6 @@ int SDCFsiSolver::getDOF()
     return dofFluid + dofSolid;
 }
 
-scalar SDCFsiSolver::getScalingFactor()
-{
-    return 1;
-}
-
 void SDCFsiSolver::getSolution(
     fsi::vector & solution,
     fsi::vector & f

--- a/src/fsi/SDCFsiSolver.H
+++ b/src/fsi/SDCFsiSolver.H
@@ -35,8 +35,6 @@ public:
 
         virtual int getDOF();
 
-        virtual scalar getScalingFactor();
-
         virtual void getSolution(
             fsi::vector & solution,
             fsi::vector & f

--- a/src/fsi/SDCSolver.H
+++ b/src/fsi/SDCSolver.H
@@ -29,8 +29,6 @@ public:
 
         virtual int getDOF() = 0;
 
-        virtual scalar getScalingFactor() = 0;
-
         virtual void getSolution(
             fsi::vector & solution,
             fsi::vector & f

--- a/src/fsi/fluidSolvers/SDCDynamicMeshFluidSolver.C
+++ b/src/fsi/fluidSolvers/SDCDynamicMeshFluidSolver.C
@@ -754,11 +754,6 @@ void SDCDynamicMeshFluidSolver::implicitSolve(
     getSolution( result, f );
 }
 
-scalar SDCDynamicMeshFluidSolver::getScalingFactor()
-{
-    return 1;
-}
-
 void SDCDynamicMeshFluidSolver::getVariablesInfo(
     std::deque<int> & dof,
     std::deque<bool> & enabled,

--- a/src/fsi/fluidSolvers/SDCDynamicMeshFluidSolver.H
+++ b/src/fsi/fluidSolvers/SDCDynamicMeshFluidSolver.H
@@ -50,8 +50,6 @@ public:
         const fsi::vector & f
         );
 
-    virtual scalar getScalingFactor();
-
     virtual void implicitSolve(
         bool corrector,
         const int k,

--- a/src/fsi/fluidSolvers/SDCFluidSolver.C
+++ b/src/fsi/fluidSolvers/SDCFluidSolver.C
@@ -960,11 +960,6 @@ void SDCFluidSolver::implicitSolve(
     getSolution( result, f );
 }
 
-scalar SDCFluidSolver::getScalingFactor()
-{
-    return 1;
-}
-
 void SDCFluidSolver::getVariablesInfo(
     std::deque<int> & dof,
     std::deque<bool> & enabled,

--- a/src/fsi/fluidSolvers/SDCFluidSolver.H
+++ b/src/fsi/fluidSolvers/SDCFluidSolver.H
@@ -77,8 +77,6 @@ public:
 
     virtual scalar getEndTime();
 
-    virtual scalar getScalingFactor();
-
     virtual scalar getTimeStep();
 
     virtual scalar getStartTime();

--- a/src/fsi/fluidSolvers/SDCLaplacianSolver.C
+++ b/src/fsi/fluidSolvers/SDCLaplacianSolver.C
@@ -108,11 +108,6 @@ int SDCLaplacianSolver::getDOF()
     return T.size();
 }
 
-scalar SDCLaplacianSolver::getScalingFactor()
-{
-    return 1;
-}
-
 void SDCLaplacianSolver::getSolution( fsi::vector & solution )
 {
     for ( int i = 0; i < T.size(); i++ )

--- a/src/fsi/fluidSolvers/SDCLaplacianSolver.H
+++ b/src/fsi/fluidSolvers/SDCLaplacianSolver.H
@@ -40,8 +40,6 @@ public:
 
     virtual int getDOF();
 
-    virtual scalar getScalingFactor();
-
     virtual void getSolution( fsi::vector & solution );
 
     virtual void setSolution(

--- a/src/fsi/solidSolvers/SDCSolidSolver.C
+++ b/src/fsi/solidSolvers/SDCSolidSolver.C
@@ -617,11 +617,6 @@ int SDCSolidSolver::getDOF()
     return index;
 }
 
-scalar SDCSolidSolver::getScalingFactor()
-{
-    return std::sqrt( gSumMag( V ) + gSumMag( U ) );
-}
-
 void SDCSolidSolver::getSolution(
     fsi::vector & solution,
     fsi::vector & f

--- a/src/fsi/solidSolvers/SDCSolidSolver.H
+++ b/src/fsi/solidSolvers/SDCSolidSolver.H
@@ -58,8 +58,6 @@ public:
 
     virtual int getDOF();
 
-    virtual scalar getScalingFactor();
-
     virtual void getSolution(
         fsi::vector & solution,
         fsi::vector & f

--- a/src/tests/app/Cos.C
+++ b/src/tests/app/Cos.C
@@ -55,11 +55,6 @@ int Cos::getDOF()
     return 1;
 }
 
-scalar Cos::getScalingFactor()
-{
-    return 1.0;
-}
-
 void Cos::getSolution(
     fsi::vector & solution,
     fsi::vector & f

--- a/src/tests/app/Cos.H
+++ b/src/tests/app/Cos.H
@@ -35,8 +35,6 @@ public:
 
     virtual int getDOF();
 
-    virtual scalar getScalingFactor();
-
     virtual void getSolution(
         fsi::vector & solution,
         fsi::vector & f

--- a/src/tests/app/Oscillator.C
+++ b/src/tests/app/Oscillator.C
@@ -54,11 +54,6 @@ int Oscillator::getDOF()
     return 2;
 }
 
-scalar Oscillator::getScalingFactor()
-{
-    return 1.0;
-}
-
 void Oscillator::getSolution(
     fsi::vector & solution,
     fsi::vector & f

--- a/src/tests/app/Oscillator.H
+++ b/src/tests/app/Oscillator.H
@@ -38,8 +38,6 @@ public:
 
     virtual int getDOF();
 
-    virtual scalar getScalingFactor();
-
     virtual void getSolution(
         fsi::vector & solution,
         fsi::vector & f

--- a/src/tests/app/Piston.H
+++ b/src/tests/app/Piston.H
@@ -101,11 +101,6 @@ public:
 
     virtual void nextTimeStep();
 
-    virtual scalar getScalingFactor()
-    {
-        return 1;
-    }
-
     virtual void getVariablesInfo(
         std::deque<int> & dof,
         std::deque<bool> & enabled,


### PR DESCRIPTION
Remove the SDCSolver::getScalingFactor() method in order to simplify the SDC interface.
Use a relative convergence measure for the SDC sweeps in order to be able to compare different variables to each other.