### PR TITLE
SDC time integration: fixes for the boundary condition and relative residual

### DIFF
--- a/src/fsi/SDC.C
+++ b/src/fsi/SDC.C
@@ -494,14 +494,14 @@ namespace sdc
     {
         fsi::matrix Qj = dt * (qmat * F);
         fsi::matrix residual = solStages.row( 0 ) + Qj.row( k - 2 ) - solStages.row( k - 1 );
+        fsi::matrix diff = Qj.row( k - 2 );
 
-        scalarList squaredNorm( Pstream::nProcs(), scalar( 0 ) );
-        labelList dofs( Pstream::nProcs(), label( 0 ) );
-        squaredNorm[Pstream::myProcNo()] = residual.squaredNorm();
-        dofs[Pstream::myProcNo()] = F.cols();
-        reduce( squaredNorm, sumOp<scalarList>() );
-        reduce( dofs, sumOp<labelList>() );
-        scalar error = std::sqrt( sum( squaredNorm ) / sum( dofs ) );
+        scalarList squaredNormResidual( Pstream::nProcs(), scalar( 0 ) ), squaredNormDiff( Pstream::nProcs(), scalar( 0 ) );
+        squaredNormResidual[Pstream::myProcNo()] = residual.squaredNorm();
+        squaredNormDiff[Pstream::myProcNo()] = diff.squaredNorm();
+        reduce( squaredNormResidual, sumOp<scalarList>() );
+        reduce( squaredNormDiff, sumOp<scalarList>() );
+        scalar error = std::sqrt( sum( squaredNormResidual ) / sum( squaredNormDiff ) );
         convergence = error < tol;
 
         Info << "SDC " << name.c_str();

--- a/src/fsi/fluidSolvers/SDCDynamicMeshFluidSolver.C
+++ b/src/fsi/fluidSolvers/SDCDynamicMeshFluidSolver.C
@@ -203,7 +203,8 @@ int SDCDynamicMeshFluidSolver::getDOF()
 
     forAll( U.boundaryField(), patchI )
     {
-        if ( U.boundaryField().types()[patchI] != "SDCMovingWallVelocity" )
+        if ( U.boundaryField().types()[patchI] != "SDCMovingWallVelocity"
+            && U.boundaryField().types()[patchI] != "transitionalParabolicVelocity" )
         {
             forAll( U.boundaryField()[patchI], i )
             {
@@ -283,7 +284,8 @@ void SDCDynamicMeshFluidSolver::getSolution(
 
     forAll( U.boundaryField(), patchI )
     {
-        if ( U.boundaryField().types()[patchI] != "SDCMovingWallVelocity" )
+        if ( U.boundaryField().types()[patchI] != "SDCMovingWallVelocity"
+            && U.boundaryField().types()[patchI] != "transitionalParabolicVelocity" )
         {
             forAll( U.boundaryField()[patchI], i )
             {
@@ -348,7 +350,8 @@ void SDCDynamicMeshFluidSolver::getSolution(
 
     forAll( UF.boundaryField(), patchI )
     {
-        if ( U.boundaryField().types()[patchI] != "SDCMovingWallVelocity" )
+        if ( U.boundaryField().types()[patchI] != "SDCMovingWallVelocity"
+            && U.boundaryField().types()[patchI] != "transitionalParabolicVelocity" )
         {
             forAll( UF.boundaryField()[patchI], i )
             {
@@ -535,7 +538,8 @@ void SDCDynamicMeshFluidSolver::evaluateFunction(
 
     forAll( UF.boundaryField(), patchI )
     {
-        if ( U.boundaryField().types()[patchI] != "SDCMovingWallVelocity" )
+        if ( U.boundaryField().types()[patchI] != "SDCMovingWallVelocity"
+            && U.boundaryField().types()[patchI] != "transitionalParabolicVelocity" )
         {
             forAll( UF.boundaryField()[patchI], i )
             {
@@ -646,7 +650,8 @@ void SDCDynamicMeshFluidSolver::prepareImplicitSolve(
 
     forAll( rhsU.boundaryField(), patchI )
     {
-        if ( U.boundaryField().types()[patchI] != "SDCMovingWallVelocity" )
+        if ( U.boundaryField().types()[patchI] != "SDCMovingWallVelocity"
+            && U.boundaryField().types()[patchI] != "transitionalParabolicVelocity" )
         {
             forAll( rhsU.boundaryField()[patchI], i )
             {
@@ -780,7 +785,8 @@ void SDCDynamicMeshFluidSolver::getVariablesInfo(
 
     forAll( U.boundaryField(), patchI )
     {
-        if ( U.boundaryField().types()[patchI] != "SDCMovingWallVelocity" )
+        if ( U.boundaryField().types()[patchI] != "SDCMovingWallVelocity"
+            && U.boundaryField().types()[patchI] != "transitionalParabolicVelocity" )
         {
             forAll( U.boundaryField()[patchI], i )
             {


### PR DESCRIPTION
1. The scaling of the residual is based on the change of the solution with respect to the previous time step. The SDC scheme uses the same convergence measure.
2. The boundary conditions also use a relative convergence measure
3. SDC fluid solver: do not include the transitionalParabolicVelocity boundary condition into the SDC scheme.