### PR TITLE
Add check to the fluid and solid solver

### DIFF
--- a/src/fsi/fluidSolvers/foamFluidSolver.C
+++ b/src/fsi/fluidSolvers/foamFluidSolver.C
@@ -77,6 +77,8 @@ foamFluidSolver::foamFluidSolver(
     dim = mesh.nGeometricD();
     data.resize( N, dim );
     data.setZero();
+
+    assert( readLabel( runTime->controlDict().lookup( "writePrecision" ) ) >= 12 );
 }
 
 foamFluidSolver::~foamFluidSolver()

--- a/src/fsi/solidSolvers/foamSolidSolver.C
+++ b/src/fsi/solidSolvers/foamSolidSolver.C
@@ -86,6 +86,8 @@ foamSolidSolver::foamSolidSolver (
     data.setZero();
 
     readCouplingProperties();
+
+    assert( readLabel( runTime->controlDict().lookup( "writePrecision" ) ) >= 12 );
 }
 
 foamSolidSolver::~foamSolidSolver()


### PR DESCRIPTION
Assert that the writePrecision is set to 12 or higher. For time stepping
studies the write precision needs to be set appropriately and is
often the cause of presumably order reduction of the solution.
However, the order reduction is caused by the post processing step.