### PR TITLE
Update compile_supermuc

### DIFF
--- a/src/thirdParty/compile_supermuc
+++ b/src/thirdParty/compile_supermuc
@@ -25,8 +25,9 @@ cd ../
 BOOST_VERSION=1_55_0
 BOOST_VERSION_DOT=1.55.0
 
-rm -rf boost_${BOOST_VERSION}
-tar jxf boost_${BOOST_VERSION}.tar.bz2
+if [ ! -d "boost_${BOOST_VERSION}" ]; then
+    tar jxf boost_${BOOST_VERSION}.tar.bz2
+fi
 
 # Set environment variables necessary for building preCICE
 

--- a/src/thirdParty/compile_supermuc
+++ b/src/thirdParty/compile_supermuc
@@ -26,7 +26,7 @@ BOOST_VERSION=1_55_0
 BOOST_VERSION_DOT=1.55.0
 
 rm -rf boost_${BOOST_VERSION}
-tar jxfv boost_${BOOST_VERSION}.tar.bz2
+tar jxf boost_${BOOST_VERSION}.tar.bz2
 
 # Set environment variables necessary for building preCICE
 


### PR DESCRIPTION
supermuc: only unpack the boost archive in case the boost directory does not exist.
Future builds of the third party packages are possibly speedup in case the boost archive is already extracted.