### PR TITLE
Suppress warning of gcc 5 of the third party libraries

### DIFF
--- a/applications/solvers/fsi/fsiFoam/Make/options
+++ b/applications/solvers/fsi/fsiFoam/Make/options
@@ -1,27 +1,27 @@
 c++WARN     = -Wall -Wextra -Wno-unused-parameter -Wnon-virtual-dtor -Wunused-local-typedefs -Werror -Wredundant-decls -Wcast-align -Wmissing-declarations  -Wswitch-enum -Wswitch-default -Winvalid-pch -Wredundant-decls -Wformat=2 -Wmissing-format-attribute -Wformat-nonliteral
 
 EXE_INC = -std=c++11 \
-    -I../../../../src/fsi/lnInclude \
-    -I../../../../src/thirdParty/eigen \
+    -isystem ../../../../src/fsi/lnInclude \
+    -isystem ../../../../src/thirdParty/eigen \
     -isystem $(LIB_SRC)/finiteVolume/lnInclude \
-    -I$(LIB_SRC)/thermophysicalModels/basic/lnInclude \
-    -I$(LIB_SRC)/dynamicMesh/dynamicFvMesh/lnInclude \
-    -I$(LIB_SRC)/dynamicMesh/dynamicMesh/lnInclude \
-    -I$(LIB_SRC)/transportModels \
-    -I$(LIB_SRC)/transportModels/incompressible/singlePhaseTransportModel \
-    -I$(LIB_SRC)/turbulenceModels \
-    -I$(LIB_SRC)/turbulenceModels/incompressible/turbulenceModel \
-    -I$(LIB_SRC)/turbulenceModels/incompressible/RAS/RASModel \
-    -I$(LIB_SRC)/turbulenceModels/compressible/RAS/RASModel \
-    -I$(LIB_SRC)/meshTools/lnInclude \
-    -I$(LIB_SRC)/sampling/lnInclude \
-    -I$(LIB_SRC)/solidModels/lnInclude \
+    -isystem $(LIB_SRC)/thermophysicalModels/basic/lnInclude \
+    -isystem $(LIB_SRC)/dynamicMesh/dynamicFvMesh/lnInclude \
+    -isystem $(LIB_SRC)/dynamicMesh/dynamicMesh/lnInclude \
+    -isystem $(LIB_SRC)/transportModels \
+    -isystem $(LIB_SRC)/transportModels/incompressible/singlePhaseTransportModel \
+    -isystem $(LIB_SRC)/turbulenceModels \
+    -isystem $(LIB_SRC)/turbulenceModels/incompressible/turbulenceModel \
+    -isystem $(LIB_SRC)/turbulenceModels/incompressible/RAS/RASModel \
+    -isystem $(LIB_SRC)/turbulenceModels/compressible/RAS/RASModel \
+    -isystem $(LIB_SRC)/meshTools/lnInclude \
+    -isystem $(LIB_SRC)/sampling/lnInclude \
+    -isystem $(LIB_SRC)/solidModels/lnInclude \
     -isystem ../../../../src/thirdParty/yaml-cpp/include \
-    -I../../../../src/RBFMeshMotionSolver/lnInclude/ \
+    -isystem ../../../../src/RBFMeshMotionSolver/lnInclude/ \
     $(WM_DECOMP_INC) \
-    -I$(LIB_SRC)/tetFiniteElement/lnInclude \
+    -isystem $(LIB_SRC)/tetFiniteElement/lnInclude \
     -isystem ../../../../src/thirdParty/boost \
-    -I../../../../src/boundaryConditions/lnInclude
+    -isystem ../../../../src/boundaryConditions/lnInclude
 
 EXE_LIBS = \
     -L$(FOAM_USER_LIBBIN) \

--- a/src/boundaryConditions/Make/options
+++ b/src/boundaryConditions/Make/options
@@ -1,11 +1,11 @@
 c++WARN     = -Wall -Wextra -Wno-unused-parameter -Wnon-virtual-dtor -Wunused-local-typedefs -Werror -Wredundant-decls -Wcast-align -Wmissing-declarations  -Wswitch-enum -Winvalid-pch -Wredundant-decls -Wformat=2 -Wmissing-format-attribute -Wformat-nonliteral
 
 EXE_INC = -std=c++11 \
-	-I$(LIB_SRC)/finiteVolume/lnInclude \
-	-I../fsi/lnInclude \
-	-I../thirdParty/eigen \
-	-I../thirdParty/yaml-cpp/include \
-	-I../thirdParty/boost
+	-isystem $(LIB_SRC)/finiteVolume/lnInclude \
+	-isystem ../fsi/lnInclude \
+	-isystem ../thirdParty/eigen \
+	-isystem ../thirdParty/yaml-cpp/include \
+	-isystem ../thirdParty/boost
 
 LIB_LIBS = \
 	-L$(FOAM_USER_LIBBIN) \

--- a/src/fsi/AdaptiveTimeStepper.H
+++ b/src/fsi/AdaptiveTimeStepper.H
@@ -23,7 +23,7 @@ namespace sdc
     {
 public:
 
-        AdaptiveTimeStepper( bool enabled );
+        explicit AdaptiveTimeStepper( bool enabled );
 
         AdaptiveTimeStepper(
             bool enabled,

--- a/src/fsi/ESDIRK.H
+++ b/src/fsi/ESDIRK.H
@@ -25,7 +25,7 @@ public:
             std::shared_ptr<AdaptiveTimeStepper> adaptiveTimeStepper
             );
 
-        ESDIRK( std::string method );
+        explicit ESDIRK( std::string method );
 
         ~ESDIRK();
 

--- a/src/tests/app/Make/options
+++ b/src/tests/app/Make/options
@@ -1,25 +1,25 @@
 c++WARN     = -Wall -Wextra -Wno-unused-parameter -Wnon-virtual-dtor -Wunused-local-typedefs -Werror
 
 EXE_INC = --coverage -fprofile-arcs -ftest-coverage -g -std=c++11 \
-    -I../../RBFmeshInterpolation/lnInclude/ \
-    -I$(LIB_SRC)/finiteVolume/lnInclude \
-    -I$(LIB_SRC)/dynamicMesh/lnInclude \
-    -I$(LIB_SRC)/dynamicMesh/dynamicFvMesh/lnInclude \
-    -I$(LIB_SRC)/dynamicMesh/dynamicMesh/lnInclude \
-    -I$(LIB_SRC)/transportModels \
-    -I$(LIB_SRC)/transportModels/incompressible/singlePhaseTransportModel \
-    -I$(LIB_SRC)/turbulenceModels \
-    -I$(LIB_SRC)/turbulenceModels/incompressible/turbulenceModel \
-    -I$(LIB_SRC)/turbulenceModels/incompressible/RAS/RASModel \
-    -I../../thirdParty/eigen \
+    -isystem ../../RBFmeshInterpolation/lnInclude/ \
+    -isystem $(LIB_SRC)/finiteVolume/lnInclude \
+    -isystem $(LIB_SRC)/dynamicMesh/lnInclude \
+    -isystem $(LIB_SRC)/dynamicMesh/dynamicFvMesh/lnInclude \
+    -isystem $(LIB_SRC)/dynamicMesh/dynamicMesh/lnInclude \
+    -isystem $(LIB_SRC)/transportModels \
+    -isystem $(LIB_SRC)/transportModels/incompressible/singlePhaseTransportModel \
+    -isystem $(LIB_SRC)/turbulenceModels \
+    -isystem $(LIB_SRC)/turbulenceModels/incompressible/turbulenceModel \
+    -isystem $(LIB_SRC)/turbulenceModels/incompressible/RAS/RASModel \
+    -isystem ../../thirdParty/eigen \
     -isystem ../../thirdParty/boost \
-    -I../../thirdParty/gtest/include \
+    -isystem ../../thirdParty/gtest/include \
     $(WM_DECOMP_INC) \
-    -I$(LIB_SRC)/tetFiniteElement/lnInclude \
-    -I../../RBFMeshMotionSolver/lnInclude/ \
-    -I$(LIB_SRC)/meshTools/lnInclude \
-    -I$(LIB_SRC)/solidModels/lnInclude \
-    -I$(LIB_SRC)/VectorN/lnInclude
+    -isystem $(LIB_SRC)/tetFiniteElement/lnInclude \
+    -isystem ../../RBFMeshMotionSolver/lnInclude/ \
+    -isystem $(LIB_SRC)/meshTools/lnInclude \
+    -isystem $(LIB_SRC)/solidModels/lnInclude \
+    -isystem $(LIB_SRC)/VectorN/lnInclude
 
 EXE_LIBS = \
     -L$(FOAM_USER_LIBBIN) \

--- a/src/tests/app/Make/options
+++ b/src/tests/app/Make/options
@@ -1,25 +1,25 @@
 c++WARN     = -Wall -Wextra -Wno-unused-parameter -Wnon-virtual-dtor -Wunused-local-typedefs -Werror
 
 EXE_INC = --coverage -fprofile-arcs -ftest-coverage -g -std=c++11 \
-    -isystem ../../RBFmeshInterpolation/lnInclude/ \
-    -isystem $(LIB_SRC)/finiteVolume/lnInclude \
-    -isystem $(LIB_SRC)/dynamicMesh/lnInclude \
-    -isystem $(LIB_SRC)/dynamicMesh/dynamicFvMesh/lnInclude \
-    -isystem $(LIB_SRC)/dynamicMesh/dynamicMesh/lnInclude \
-    -isystem $(LIB_SRC)/transportModels \
-    -isystem $(LIB_SRC)/transportModels/incompressible/singlePhaseTransportModel \
-    -isystem $(LIB_SRC)/turbulenceModels \
-    -isystem $(LIB_SRC)/turbulenceModels/incompressible/turbulenceModel \
-    -isystem $(LIB_SRC)/turbulenceModels/incompressible/RAS/RASModel \
+    -I ../../RBFmeshInterpolation/lnInclude/ \
+    -I $(LIB_SRC)/finiteVolume/lnInclude \
+    -I $(LIB_SRC)/dynamicMesh/lnInclude \
+    -I $(LIB_SRC)/dynamicMesh/dynamicFvMesh/lnInclude \
+    -I $(LIB_SRC)/dynamicMesh/dynamicMesh/lnInclude \
+    -I $(LIB_SRC)/transportModels \
+    -I $(LIB_SRC)/transportModels/incompressible/singlePhaseTransportModel \
+    -I $(LIB_SRC)/turbulenceModels \
+    -I $(LIB_SRC)/turbulenceModels/incompressible/turbulenceModel \
+    -I $(LIB_SRC)/turbulenceModels/incompressible/RAS/RASModel \
     -isystem ../../thirdParty/eigen \
     -isystem ../../thirdParty/boost \
-    -isystem ../../thirdParty/gtest/include \
+    -I ../../thirdParty/gtest/include \
     $(WM_DECOMP_INC) \
-    -isystem $(LIB_SRC)/tetFiniteElement/lnInclude \
-    -isystem ../../RBFMeshMotionSolver/lnInclude/ \
-    -isystem $(LIB_SRC)/meshTools/lnInclude \
-    -isystem $(LIB_SRC)/solidModels/lnInclude \
-    -isystem $(LIB_SRC)/VectorN/lnInclude
+    -I $(LIB_SRC)/tetFiniteElement/lnInclude \
+    -I ../../RBFMeshMotionSolver/lnInclude/ \
+    -I $(LIB_SRC)/meshTools/lnInclude \
+    -I $(LIB_SRC)/solidModels/lnInclude \
+    -I $(LIB_SRC)/VectorN/lnInclude
 
 EXE_LIBS = \
     -L$(FOAM_USER_LIBBIN) \

--- a/src/tests/app/test_manifoldmapping.C
+++ b/src/tests/app/test_manifoldmapping.C
@@ -16,7 +16,7 @@ class FineModelParabola : public SurrogateModel
 {
 public:
 
-    FineModelParabola ( scalar tol )
+    explicit FineModelParabola ( scalar tol )
         :
         tol( tol ),
         iter( 0 ),
@@ -190,7 +190,7 @@ class FineModelSimple : public SurrogateModel
 {
 public:
 
-    FineModelSimple( scalar tol )
+    explicit FineModelSimple( scalar tol )
         :
         tol( tol ),
         iter( 0 ),


### PR DESCRIPTION
Fix warnings of cppcheck. The ESDIRK, AdaptiveTimeStepper, manifold
mapping classes have constructors with 1 argument which is marked
as explicit.