### PR TITLE
mapMesh: the mesh.update() method needs to be called

### DIFF
--- a/applications/utilities/mapMesh/mapMesh.C
+++ b/applications/utilities/mapMesh/mapMesh.C
@@ -212,7 +212,8 @@ int main(
 
     fluid->setDisplacementLocal( valuesInterpolation );
     fluid->moveMesh();
-
+    fluid->mesh.update();
+    
     runTime->loop();
     runTime->write();
 }


### PR DESCRIPTION
In order to actually move the mesh.