### PR TITLE
Update wercker.yml

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -229,9 +229,6 @@ build:
                     tar -zcf dealii-${DEALII_VERSION}.tar.gz dealii-${DEALII_VERSION}
                     rsync -azvh dealii-${DEALII_VERSION}.tar.gz $WERCKER_CACHE_DIR/
                 fi
-
-                cd deal-fsi
-                make release run
         - script:
             name: googletest
             code: |


### PR DESCRIPTION
Do not run the deal-fsi unit test suite in order to speedup the continuous integration. The implementation is also tested by the SDC time integration tests.