### PR TITLE
wercker: enable cppcheck for src/fsi and src/RBFMeshMotionSolver

### DIFF
--- a/wercker.yml
+++ b/wercker.yml
@@ -599,3 +599,9 @@ build:
 
                 cd src/tests
                 python runTests.py testsuite-dealii
+        - script:
+            name: cppcheck
+            code: |
+                (cd src/fsi && cppcheck --enable=performance,portability .)
+                (cd src/RBFMeshMotionSolver && cppcheck --enable=performance,portability .)
+                

--- a/wercker.yml
+++ b/wercker.yml
@@ -9,7 +9,7 @@ build:
             name: install packages
             code: |
                 apt-get update
-                apt-get -y install git build-essential flex bison zlib1g-dev libreadline-dev libncurses-dev libxt-dev libopenmpi-dev openmpi-bin rpm wget cmake hwloc scotch gfortran python unzip scons libiberty-dev libscotch-dev liblapack-dev libblas-dev
+                apt-get -y install git build-essential flex bison zlib1g-dev libreadline-dev libncurses-dev libxt-dev libopenmpi-dev openmpi-bin rpm wget cmake hwloc scotch gfortran python unzip scons libiberty-dev libscotch-dev liblapack-dev libblas-dev cppcheck
         - script:
             name: initialize git submodules
             code: |


### PR DESCRIPTION
Enable cppcheck for src/fsi and src/RBFMeshMotionSolver