### PR TITLE
precice: read the $PRECICE_ROOT environment variable (fixes #149)

### DIFF
--- a/applications/solvers/fsi/fsiFluidFoam/Make/options
+++ b/applications/solvers/fsi/fsiFluidFoam/Make/options
@@ -1,5 +1,9 @@
 c++WARN     = -Wall -Wextra -Werror
 
+ifndef PRECICE_ROOT
+    PRECICE_ROOT=../../../../src/thirdParty/precice
+endif
+
 EXE_INC = -std=c++11 \
     -I../../../../src/fsi/lnInclude \
     -isystem ../../../../src/thirdParty/eigen \
@@ -14,7 +18,7 @@ EXE_INC = -std=c++11 \
     -I$(LIB_SRC)/turbulenceModels/incompressible/RAS/RASModel \
     -I$(LIB_SRC)/meshTools/lnInclude \
     -I$(LIB_SRC)/solidModels/lnInclude \
-    -I../../../../src/thirdParty/precice/src \
+    -I$(PRECICE_ROOT)/src \
     -isystem ../../../../src/thirdParty/boost \
     -I../../../../src/thirdParty \
     -I../../../../src/RBFMeshMotionSolver/lnInclude/ \

--- a/applications/solvers/fsi/fsiSolidFoam/Make/options
+++ b/applications/solvers/fsi/fsiSolidFoam/Make/options
@@ -1,5 +1,9 @@
 c++WARN     = -Wall -Wextra -Werror
 
+ifndef PRECICE_ROOT
+    PRECICE_ROOT=../../../../src/thirdParty/precice
+endif
+
 EXE_INC = -std=c++11 \
     -I../../../../src/fsi/lnInclude \
     -isystem ../../../../src/thirdParty/eigen \
@@ -12,7 +16,7 @@ EXE_INC = -std=c++11 \
     -isystem $(LIB_SRC)/meshTools/lnInclude \
     -isystem $(LIB_SRC)/sampling/lnInclude \
     -isystem $(LIB_SRC)/solidModels/lnInclude \
-    -isystem ../../../../src/thirdParty/precice/src \
+    -isystem $(PRECICE_ROOT)/src \
     -isystem ../../../../src/thirdParty/boost \
     -isystem../../../../src/thirdParty \
     $(WM_DECOMP_INC) \


### PR DESCRIPTION
In case the variable is not set, the bundled version of precice is used.
It is always assumed that the libprecice.so library is available.
The bundled version of precice copies the library to $FOAM_LIBBIN.