### PR TITLE
Bugfix precice fluid adapter: floating point exception

### DIFF
--- a/applications/solvers/fsi/fsiFluidFoam/PreciceFluidSolver.C
+++ b/applications/solvers/fsi/fsiFluidFoam/PreciceFluidSolver.C
@@ -74,6 +74,7 @@ void PreciceFluidSolver::run()
     matrix input( solver->getInterfaceSizeLocal(), precice->getDimensions() );
     matrix output;
     inputOld.setZero();
+    input.setZero();
 
     while ( solver->isRunning() )
     {


### PR DESCRIPTION
in case of fluid-acoustics coupling with ateles