### PR TITLE
Bugfix running SDC in parallel

### DIFF
--- a/src/fsi/SDC.C
+++ b/src/fsi/SDC.C
@@ -313,11 +313,6 @@ namespace sdc
 
                     for ( unsigned int i = 0; i < dofVariables.size(); i++ )
                     {
-                        if ( not enabledVariables.at( i ) && dofVariables.at( i ) == 0 )
-                            continue;
-
-                        assert( dofVariables.at( i ) > 0 );
-
                         scalarList squaredNormResidual( Pstream::nProcs(), scalar( 0 ) );
                         labelList dof( Pstream::nProcs(), label( 0 ) );
 
@@ -491,6 +486,7 @@ namespace sdc
         squaredNormResidual[Pstream::myProcNo()] = residual.squaredNorm();
         reduce( squaredNormResidual, sumOp<scalarList>() );
         dof[Pstream::myProcNo()] = residual.rows() * residual.cols();
+        reduce( dof, sumOp<labelList>() );
         scalar error = std::sqrt( sum( squaredNormResidual ) / sum( dof ) );
         convergence = error < tol;
 

--- a/src/fsi/fluidSolvers/SDCDynamicMeshFluidSolver.C
+++ b/src/fsi/fluidSolvers/SDCDynamicMeshFluidSolver.C
@@ -791,9 +791,7 @@ void SDCDynamicMeshFluidSolver::getVariablesInfo(
             && U.boundaryField().types()[patchI] != "fixedValue"
             && U.boundaryField().types()[patchI] != "empty" )
         {
-            dof.push_back( U.boundaryField()[patchI].size() * mesh.nGeometricD() );
-            enabled.push_back( true );
-            names.push_back( "fluid patch " + mesh.boundaryMesh()[patchI].name() );
+            dof.back() += U.boundaryField()[patchI].size() * mesh.nGeometricD();
         }
     }
 
@@ -1033,7 +1031,7 @@ void SDCDynamicMeshFluidSolver::solve()
             U -= fvc::grad( p ) / AU;
             U.correctBoundaryConditions();
 
-            if ( currResidual < std::max( tol * initResidual, scalar( 1.0e-15 ) ) )
+            if ( currResidual < std::max( tol * initResidual, scalar( 1.0e-20 ) ) )
                 break;
         }
 


### PR DESCRIPTION
The patch names for the flow solver are not shown, since proctoproc
patches are automatically created when running in parallel. These
patches do not exist on each processor causing a deadlock in the
SDC residual output.