### PR TITLE
Bugfix SDC moving mesh solver: the rhsU term in the momentum residual

### DIFF
--- a/src/fsi/fluidSolvers/SDCDynamicMeshFluidSolver.H
+++ b/src/fsi/fluidSolvers/SDCDynamicMeshFluidSolver.H
@@ -90,6 +90,8 @@ class SDCDynamicMeshFluidSolver : public SDCFluidSolver
     private:
         void createFields();
 
+        scalar evaluateMomentumResidual();
+
         void initialize();
 
         // Fields


### PR DESCRIPTION
needs to be scaled by the cell volumes.