### PR TITLE
Bugfixes for running unsteady simulations

### DIFF
--- a/applications/solvers/fsi/fsiFoam/fsiFoam.C
+++ b/applications/solvers/fsi/fsiFoam/fsiFoam.C
@@ -204,6 +204,7 @@ int main(
     assert( configInterpolation["coarsening"]["enabled"] );
     assert( configInterpolation["radial-basis-function"] );
     assert( configInterpolation["radial-basis-function"]["function"] );
+    assert( configInterpolation["radial-basis-function"]["cpu"] );
     bool coarsening = configInterpolation["coarsening"]["enabled"].as<bool>();
     std::string interpolationFunction = configInterpolation["radial-basis-function"]["function"].as<std::string>();
     scalar coarseningTol = 1.0e-5;
@@ -212,14 +213,9 @@ int main(
     scalar radius = 1;
     bool livePointSelection = false;
     scalar tolLivePointSelection = 1.0e-5;
-    bool cpu = false;
+    bool cpu = configInterpolation["radial-basis-function"]["cpu"].as<bool>();
 
     assert( interpolationFunction == "thin-plate-spline" || interpolationFunction == "wendland-c0" || interpolationFunction == "wendland-c2" || interpolationFunction == "wendland-c4" || interpolationFunction == "wendland-c6" );
-
-    if ( configInterpolation["radial-basis-function"]["cpu"] )
-    {
-        cpu = configInterpolation["radial-basis-function"]["cpu"].as<bool>();
-    }
 
     if ( interpolationFunction != "thin-plate-spline" )
     {
@@ -712,13 +708,13 @@ int main(
             {
                 assert( not adaptiveTimeStepping );
 
-                solid = std::shared_ptr<BaseMultiLevelSolver>( new dealiiSolidSolver<2> ( data ) );
+                solid = std::shared_ptr<BaseMultiLevelSolver>( new dealiiSolidSolver<3> ( data ) );
             }
 
             if ( timeIntegrationScheme == "esdirk" || timeIntegrationScheme == "sdc" || timeIntegrationScheme == "picard-integral-exponential-solver" )
             {
                 data.theta = 1;
-                sdcSolidSolver = std::shared_ptr<sdc::SDCFsiSolverInterface> ( new dealiiSolidSolver<2> ( data ) );
+                sdcSolidSolver = std::shared_ptr<sdc::SDCFsiSolverInterface> ( new dealiiSolidSolver<3> ( data ) );
             }
         }
 

--- a/applications/solvers/fsi/fsiFoam/fsiFoam.C
+++ b/applications/solvers/fsi/fsiFoam/fsiFoam.C
@@ -708,13 +708,13 @@ int main(
             {
                 assert( not adaptiveTimeStepping );
 
-                solid = std::shared_ptr<BaseMultiLevelSolver>( new dealiiSolidSolver<3> ( data ) );
+                solid = std::shared_ptr<BaseMultiLevelSolver>( new dealiiSolidSolver<2> ( data ) );
             }
 
             if ( timeIntegrationScheme == "esdirk" || timeIntegrationScheme == "sdc" || timeIntegrationScheme == "picard-integral-exponential-solver" )
             {
                 data.theta = 1;
-                sdcSolidSolver = std::shared_ptr<sdc::SDCFsiSolverInterface> ( new dealiiSolidSolver<3> ( data ) );
+                sdcSolidSolver = std::shared_ptr<sdc::SDCFsiSolverInterface> ( new dealiiSolidSolver<2> ( data ) );
             }
         }
 

--- a/src/RBFMeshMotionSolver/RBFCoarsening.C
+++ b/src/RBFMeshMotionSolver/RBFCoarsening.C
@@ -481,6 +481,7 @@ namespace rbf
                 rbf->Hhat.conservativeResize( rbf->Hhat.rows(), rbf->Hhat.cols() - nbStaticFaceCentersRemove );
             }
         }
+
         usedValues.conservativeResize( usedValues.rows() - nbStaticFaceCentersRemove, usedValues.cols() );
         rbf->interpolate( usedValues, valuesInterpolation );
 

--- a/src/fsi/fluidSolvers/SDCDynamicMeshFluidSolver.C
+++ b/src/fsi/fluidSolvers/SDCDynamicMeshFluidSolver.C
@@ -233,36 +233,10 @@ int SDCDynamicMeshFluidSolver::getDOF()
         }
     }
 
-    forAll( U.boundaryField(), patchI )
-    {
-        if ( U.boundaryField().types()[patchI] != "SDCMovingWallVelocity"
-            && U.boundaryField().types()[patchI] != "transitionalParabolicVelocity"
-            && U.boundaryField().types()[patchI] != "fixedValue"
-            && U.boundaryField().types()[patchI] != "empty" )
-        {
-            forAll( U.boundaryField()[patchI], i )
-            {
-                for ( int j = 0; j < mesh.nGeometricD(); j++ )
-                {
-                    index++;
-                }
-            }
-        }
-    }
-
     forAll( Uf.internalField(), i )
     {
         for ( int j = 0; j < mesh.nGeometricD(); j++ )
             index++;
-    }
-
-    forAll( Uf.boundaryField(), patchI )
-    {
-        forAll( Uf.boundaryField()[patchI], i )
-        {
-            for ( int j = 0; j < mesh.nGeometricD(); j++ )
-                index++;
-        }
     }
 
     forAll( mesh.phi().internalField(), i )
@@ -316,42 +290,12 @@ void SDCDynamicMeshFluidSolver::getSolution(
         }
     }
 
-    forAll( U.boundaryField(), patchI )
-    {
-        if ( U.boundaryField().types()[patchI] != "SDCMovingWallVelocity"
-            && U.boundaryField().types()[patchI] != "transitionalParabolicVelocity"
-            && U.boundaryField().types()[patchI] != "fixedValue"
-            && U.boundaryField().types()[patchI] != "empty" )
-        {
-            forAll( U.boundaryField()[patchI], i )
-            {
-                for ( int j = 0; j < mesh.nGeometricD(); j++ )
-                {
-                    solution( index ) = U.boundaryField()[patchI][i][j] * V.boundaryField()[patchI][i];
-                    index++;
-                }
-            }
-        }
-    }
-
     forAll( Uf.internalField(), i )
     {
         for ( int j = 0; j < mesh.nGeometricD(); j++ )
         {
             solution( index ) = Uf.internalField()[i][j] * interpolateV.internalField()[i];
             index++;
-        }
-    }
-
-    forAll( Uf.boundaryField(), patchI )
-    {
-        forAll( Uf.boundaryField()[patchI], i )
-        {
-            for ( int j = 0; j < mesh.nGeometricD(); j++ )
-            {
-                solution( index ) = Uf.boundaryField()[patchI][i][j] * interpolateV.boundaryField()[patchI][i];
-                index++;
-            }
         }
     }
 
@@ -384,42 +328,12 @@ void SDCDynamicMeshFluidSolver::getSolution(
         }
     }
 
-    forAll( UF.boundaryField(), patchI )
-    {
-        if ( U.boundaryField().types()[patchI] != "SDCMovingWallVelocity"
-            && U.boundaryField().types()[patchI] != "transitionalParabolicVelocity"
-            && U.boundaryField().types()[patchI] != "fixedValue"
-            && U.boundaryField().types()[patchI] != "empty" )
-        {
-            forAll( UF.boundaryField()[patchI], i )
-            {
-                for ( int j = 0; j < mesh.nGeometricD(); j++ )
-                {
-                    f( index ) = UF.boundaryField()[patchI][i][j];
-                    index++;
-                }
-            }
-        }
-    }
-
     forAll( UfF.internalField(), i )
     {
         for ( int j = 0; j < mesh.nGeometricD(); j++ )
         {
             f( index ) = UfF.internalField()[i][j];
             index++;
-        }
-    }
-
-    forAll( UfF.boundaryField(), patchI )
-    {
-        forAll( UfF.boundaryField()[patchI], i )
-        {
-            for ( int j = 0; j < mesh.nGeometricD(); j++ )
-            {
-                f( index ) = UfF.boundaryField()[patchI][i][j];
-                index++;
-            }
         }
     }
 
@@ -459,36 +373,12 @@ void SDCDynamicMeshFluidSolver::setSolution(
         }
     }
 
-    forAll( U.boundaryField(), patchI )
-    {
-        forAll( U.boundaryField()[patchI], i )
-        {
-            for ( int j = 0; j < mesh.nGeometricD(); j++ )
-            {
-                U.boundaryField()[patchI][i][j] = solution( index );
-                index++;
-            }
-        }
-    }
-
     forAll( Uf.internalField(), i )
     {
         for ( int j = 0; j < mesh.nGeometricD(); j++ )
         {
             Uf.internalField()[i][j] = solution( index );
             index++;
-        }
-    }
-
-    forAll( Uf.boundaryField(), patchI )
-    {
-        forAll( Uf.boundaryField()[patchI], i )
-        {
-            for ( int j = 0; j < mesh.nGeometricD(); j++ )
-            {
-                Uf.boundaryField()[patchI][i][j] = solution( index );
-                index++;
-            }
         }
     }
 
@@ -505,36 +395,12 @@ void SDCDynamicMeshFluidSolver::setSolution(
         }
     }
 
-    forAll( UF.boundaryField(), patchI )
-    {
-        forAll( UF.boundaryField()[patchI], i )
-        {
-            for ( int j = 0; j < mesh.nGeometricD(); j++ )
-            {
-                UF.boundaryField()[patchI][i][j] = f( index );
-                index++;
-            }
-        }
-    }
-
     forAll( UfF.internalField(), i )
     {
         for ( int j = 0; j < mesh.nGeometricD(); j++ )
         {
             UfF.internalField()[i][j] = f( index );
             index++;
-        }
-    }
-
-    forAll( UfF.boundaryField(), patchI )
-    {
-        forAll( UfF.boundaryField()[patchI], i )
-        {
-            for ( int j = 0; j < mesh.nGeometricD(); j++ )
-            {
-                UfF.boundaryField()[patchI][i][j] = f( index );
-                index++;
-            }
         }
     }
 
@@ -574,42 +440,12 @@ void SDCDynamicMeshFluidSolver::evaluateFunction(
         }
     }
 
-    forAll( UF.boundaryField(), patchI )
-    {
-        if ( U.boundaryField().types()[patchI] != "SDCMovingWallVelocity"
-            && U.boundaryField().types()[patchI] != "transitionalParabolicVelocity"
-            && U.boundaryField().types()[patchI] != "fixedValue"
-            && U.boundaryField().types()[patchI] != "empty" )
-        {
-            forAll( UF.boundaryField()[patchI], i )
-            {
-                for ( int j = 0; j < mesh.nGeometricD(); j++ )
-                {
-                    f( index ) = UF.boundaryField()[patchI][i][j];
-                    index++;
-                }
-            }
-        }
-    }
-
     forAll( UfF.internalField(), i )
     {
         for ( int j = 0; j < mesh.nGeometricD(); j++ )
         {
             f( index ) = UfF.internalField()[i][j];
             index++;
-        }
-    }
-
-    forAll( UfF.boundaryField(), patchI )
-    {
-        forAll( UfF.boundaryField()[patchI], i )
-        {
-            for ( int j = 0; j < mesh.nGeometricD(); j++ )
-            {
-                f( index ) = UfF.boundaryField()[patchI][i][j];
-                index++;
-            }
         }
     }
 
@@ -692,42 +528,12 @@ void SDCDynamicMeshFluidSolver::prepareImplicitSolve(
         }
     }
 
-    forAll( rhsU.boundaryField(), patchI )
-    {
-        if ( U.boundaryField().types()[patchI] != "SDCMovingWallVelocity"
-            && U.boundaryField().types()[patchI] != "transitionalParabolicVelocity"
-            && U.boundaryField().types()[patchI] != "fixedValue"
-            && U.boundaryField().types()[patchI] != "empty" )
-        {
-            forAll( rhsU.boundaryField()[patchI], i )
-            {
-                for ( int j = 0; j < mesh.nGeometricD(); j++ )
-                {
-                    rhsU.boundaryField()[patchI][i][j] = rhs( index );
-                    index++;
-                }
-            }
-        }
-    }
-
     forAll( rhsUf.internalField(), i )
     {
         for ( int j = 0; j < mesh.nGeometricD(); j++ )
         {
             rhsUf.internalField()[i][j] = rhs( index );
             index++;
-        }
-    }
-
-    forAll( rhsUf.boundaryField(), patchI )
-    {
-        forAll( rhsUf.boundaryField()[patchI], i )
-        {
-            for ( int j = 0; j < mesh.nGeometricD(); j++ )
-            {
-                rhsUf.boundaryField()[patchI][i][j] = rhs( index );
-                index++;
-            }
         }
     }
 
@@ -789,25 +595,9 @@ void SDCDynamicMeshFluidSolver::getVariablesInfo(
     enabled.push_back( true );
     names.push_back( "fluid U" );
 
-    forAll( U.boundaryField(), patchI )
-    {
-        if ( U.boundaryField().types()[patchI] != "SDCMovingWallVelocity"
-            && U.boundaryField().types()[patchI] != "transitionalParabolicVelocity"
-            && U.boundaryField().types()[patchI] != "fixedValue"
-            && U.boundaryField().types()[patchI] != "empty" )
-        {
-            dof.back() += U.boundaryField()[patchI].size() * mesh.nGeometricD();
-        }
-    }
-
     dof.push_back( Uf.internalField().size() * mesh.nGeometricD() );
     enabled.push_back( true );
     names.push_back( "fluid Uf" );
-
-    forAll( Uf.boundaryField(), patchI )
-    {
-        dof.back() += Uf.boundaryField()[patchI].size() * mesh.nGeometricD();
-    }
 
     dof.push_back( mesh.phi().internalField().size() );
     enabled.push_back( false );
@@ -918,6 +708,8 @@ void SDCDynamicMeshFluidSolver::solve()
 
     dimensionedScalar rDeltaT = 1.0 / mesh.time().deltaT();
 
+    scalar relaxationFactor = mesh.solutionDict().relaxationFactor( "U" );
+
     // --- PIMPLE loop
     for ( label oCorr = 0; oCorr < maxIter; oCorr++ )
     {
@@ -927,11 +719,15 @@ void SDCDynamicMeshFluidSolver::solve()
 
         U.storePrevIter();
 
-        fvVectorMatrix UEqn
+        // Convection-diffusion matrix
+        fvVectorMatrix HUEqn
         (
             fvm::div( phi, U )
             - fvm::laplacian( nu, U )
         );
+
+        // Time derivative matrix
+        fvVectorMatrix ddtUEqn( fvm::ddt( U ) );
 
         fvVectorMatrix UEqnt
         (
@@ -940,33 +736,13 @@ void SDCDynamicMeshFluidSolver::solve()
             - fvm::laplacian( nu, U )
         );
 
-        {
-            // To ensure S0 and B0 are thrown out of memory
-            // Source and boundaryCoeffs need to be saved when relexation is applied
-            // to still obtain time consistent behavior.
-            // Only source is affected by relaxation, boundaryCoeffs is not relaxation
-            // dependent.
-            // BoundaryCoeffs needs to be saved to generate the correct UEqn after
-            // solving. Explicit terms (depending on U(n)) need to remain depending
-            // on U(n) and not on new solution)
-            vectorField S0 = UEqnt.source();
-            FieldField<Field, Foam::vector> B0 = UEqnt.boundaryCoeffs();
-
-            UEqnt.relax();
-
-            Foam::solve( UEqnt == -fvc::grad( p ) + rDeltaT * rhsU / V );
-
-            // Reset equation to ensure relaxation parameter is not causing problems for time order
-            UEqnt =
-                (
-                fvm::ddt( U )
-                + fvm::div( phi, U )
-                - fvm::laplacian( nu, U )
-                );
-
-            UEqnt.source() = S0;
-            UEqnt.boundaryCoeffs() = B0;
-        }
+        Foam::solve
+        (
+            ddtUEqn + relax( HUEqn, relaxationFactor )
+            ==
+            -fvc::grad( p ) + rDeltaT * rhsU / V,
+            mesh.solutionDict().solver( "U" )
+        );
 
         // Relative convergence measure for the PISO loop:
         // Perform at maximum nCorr PISO corrections.
@@ -983,11 +759,11 @@ void SDCDynamicMeshFluidSolver::solve()
         {
             p.storePrevIter();
 
-            HU = UEqn.H();
+            HU = HUEqn.H();
             AU = UEqnt.A();
 
             U = (UEqnt.H() + rDeltaT * rhsU / V) / AU;
-            Uf = (fvc::interpolate( HU ) + rDeltaT * Uf.oldTime() * interpolateVolumeStages.at( kold ) / fvc::interpolate( V ) + rDeltaT * rhsUf / fvc::interpolate( V ) ) / fvc::interpolate( AU );
+            Uf = ( fvc::interpolate( HU ) + rDeltaT * Uf.oldTime() * interpolateVolumeStages.at( kold ) / fvc::interpolate( V ) + rDeltaT * rhsUf / fvc::interpolate( V ) ) / fvc::interpolate( AU );
 
             {
                 forAll( Uf.boundaryField(), patchI )
@@ -1078,8 +854,8 @@ void SDCDynamicMeshFluidSolver::solve()
     volumeStages.at( indexk + 1 ) = mesh.V();
     interpolateVolumeStages.at( indexk + 1 ) = fvc::interpolate( V );
 
-    UF = rDeltaT * (U * V - U.oldTime() * V0 - rhsU );
-    UfF = rDeltaT * ( Uf * fvc::interpolate( V ) - Uf.oldTime() * interpolateVolumeStages.at( kold ) - rhsUf );
+    UF = rDeltaT * (U * V - U.oldTime() * V0 - rhsU);
+    UfF = rDeltaT * (Uf * fvc::interpolate( V ) - Uf.oldTime() * interpolateVolumeStages.at( kold ) - rhsUf);
     meshPhiF = mesh.phi();
 }
 

--- a/src/fvSchemes/ddtSchemes/bdf1/bdf1DdtScheme.C
+++ b/src/fvSchemes/ddtSchemes/bdf1/bdf1DdtScheme.C
@@ -427,10 +427,9 @@ namespace Foam
                 if
                 (
                     U.boundaryField()[patchI].fixesValue()
-
-                    /*|| isA<symmetryFvPatchVectorField>(U.boundaryField()[patchI])
-                    || isA<basicSymmetryFvPatchVectorField>(U.boundaryField()[patchI])
-                    || isA<slipFvPatchVectorField>(U.boundaryField()[patchI])*/
+                    || isA<symmetryFvPatchVectorField>( U.boundaryField()[patchI] )
+                    || isA<basicSymmetryFvPatchVectorField>( U.boundaryField()[patchI] )
+                    || isA<slipFvPatchVectorField>( U.boundaryField()[patchI] )
                 )
                 {
                     ddtPhiCoeff.boundaryField()[patchI] = 0.0;

--- a/src/fvSchemes/ddtSchemes/bdf2/bdf2DdtScheme.C
+++ b/src/fvSchemes/ddtSchemes/bdf2/bdf2DdtScheme.C
@@ -601,10 +601,9 @@ namespace Foam
                 if
                 (
                     U.boundaryField()[patchI].fixesValue()
-
-                    /*|| isA<symmetryFvPatchVectorField>(U.boundaryField()[patchI])
-                    || isA<basicSymmetryFvPatchVectorField>(U.boundaryField()[patchI])
-                    || isA<slipFvPatchVectorField>(U.boundaryField()[patchI])*/
+                    || isA<symmetryFvPatchVectorField>( U.boundaryField()[patchI] )
+                    || isA<basicSymmetryFvPatchVectorField>( U.boundaryField()[patchI] )
+                    || isA<slipFvPatchVectorField>( U.boundaryField()[patchI] )
                 )
                 {
                     ddtPhiCoeff.boundaryField()[patchI] = 0.0;


### PR DESCRIPTION
* fsiFoam: explicitly set cpu the mode in the fsi.yaml configuration file for the RBF interpolation between solid and fluid meshes.
* SDC solid solver: the convergence measure is based on the residual of the governing equation instead of the change in the solution.
* Bugfix ddtPhiCorrector on the boundary for symmetry boundary conditions