### PR TITLE
Bugfix SDC time integration: call solver->nextTimeStep() after requesting the solutions.

### DIFF
--- a/src/fsi/SDC.C
+++ b/src/fsi/SDC.C
@@ -189,8 +189,6 @@ namespace sdc
         assert( N > 0 );
         assert( k > 0 );
 
-        solver->nextTimeStep();
-
         fsi::vector dtsdc = this->dt * dsdc;
         fsi::matrix residual;
         fsi::vector errorEstimate( N );
@@ -207,6 +205,7 @@ namespace sdc
         fsi::vector rhs( N ), result( N );
         rhs.setZero();
 
+        solver->nextTimeStep();
         solver->initTimeStep();
 
         for ( int j = 0; j < k - 1; j++ )


### PR DESCRIPTION
Otherwise, the fluid solver resets the mesh velocity to zero due to a change of the time index when requesting mesh.phi().
This can only be observed in the logs when the debug switch `fvMesh` is enabled in `fluid/system/controlDict`.
The following text is written in the logs:

```
From function const surfaceScalarField& fvMesh::phi() const
    in file fvMesh/fvMeshGeometry.C at line 562
    Resetting mesh motion fluxes to zero
```