### PR TITLE
Refactoring build process

### DIFF
--- a/src/thirdParty/compile_elemental
+++ b/src/thirdParty/compile_elemental
@@ -1,8 +1,7 @@
 #!/bin/bash
 
 cd elemental
-rm -rf build install
-mkdir build install && cd build
+mkdir -p build install && cd build
 
 if [ "$WM_COMPILE_OPTION" = "Opt" ]
 then

--- a/src/thirdParty/compile_elemental
+++ b/src/thirdParty/compile_elemental
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -x
+
 cd elemental
 mkdir -p build install && cd build
 

--- a/src/thirdParty/compile_precice
+++ b/src/thirdParty/compile_precice
@@ -35,10 +35,10 @@ export PETSC_ARCH=x86_64
 cd precice
 if [ "$WM_COMPILE_OPTION" = "Opt" ]
 then
-    scons -j $WM_NCOMPPROCS build=release python=off petsc=on compiler=mpicxx
+    scons -j $WM_NCOMPPROCS build=release python=off petsc=on compiler=mpicxx solib
 elif [ "$WM_COMPILE_OPTION" = "Debug" ]
 then
-    scons -j $WM_NCOMPPROCS build=debug python=off petsc=on compiler=mpicxx
+    scons -j $WM_NCOMPPROCS build=debug python=off petsc=on compiler=mpicxx solib
 fi
 
 cp build/last/libprecice.* ${FOAM_LIBBIN}/

--- a/src/thirdParty/compile_precice
+++ b/src/thirdParty/compile_precice
@@ -35,10 +35,10 @@ export PETSC_ARCH=x86_64
 cd precice
 if [ "$WM_COMPILE_OPTION" = "Opt" ]
 then
-    scons -j $WM_NCOMPPROCS build=release python=off petsc=on compiler=mpicxx solib
+    scons -j $WM_NCOMPPROCS build=release python=off petsc=on compiler=mpicxx solib Symlink
 elif [ "$WM_COMPILE_OPTION" = "Debug" ]
 then
-    scons -j $WM_NCOMPPROCS build=debug python=off petsc=on compiler=mpicxx solib
+    scons -j $WM_NCOMPPROCS build=debug python=off petsc=on compiler=mpicxx solib Symlink
 fi
 
 cp build/last/libprecice.* ${FOAM_LIBBIN}/

--- a/src/thirdParty/compile_precice
+++ b/src/thirdParty/compile_precice
@@ -42,4 +42,3 @@ then
 fi
 
 cp build/last/libprecice.* ${FOAM_LIBBIN}/
-cp build/last/binprecice ${FOAM_APPBIN}/

--- a/wercker.yml
+++ b/wercker.yml
@@ -46,19 +46,7 @@ build:
             name: precice
             code: |
                 (cd /home/foam-extend-3.2 && source etc/prefs.sh && source etc/bashrc)
-
-                cd src/thirdParty
-
-                export PRECICE_MPI_LIB=mpi
-                export PRECICE_MPI_LIB_PATH="`mpicc --showme:libdirs`"
-                export PRECICE_MPI_INC_PATH="`mpicc --showme:incdirs`"
-                export CPLUS_INCLUDE_PATH=`pwd`/eigen:`pwd`/boost
-                export LIBRARY_PATH=$FOAM_LIBBIN
-
-                cd precice
-                scons -j $WM_NCOMPPROCS build=release python=off petsc=off compiler=mpicxx solib
-                cp build/release-nopetsc-nopython/libprecice.* ${FOAM_LIBBIN}/
-                rm -rf build/*
+                cd src/thirdParty && ./compile_precice
         - script:
             name: boundary conditions
             code: |
@@ -184,19 +172,7 @@ debug:
             name: precice
             code: |
                 (cd /home/foam-extend-3.2 && source etc/prefs.sh && source etc/bashrc)
-
-                cd src/thirdParty
-
-                export PRECICE_MPI_LIB=mpi
-                export PRECICE_MPI_LIB_PATH="`mpicc --showme:libdirs`"
-                export PRECICE_MPI_INC_PATH="`mpicc --showme:incdirs`"
-                export CPLUS_INCLUDE_PATH=`pwd`/eigen:`pwd`/boost
-                export LIBRARY_PATH=$FOAM_LIBBIN
-
-                cd precice
-                scons -j $WM_NCOMPPROCS build=debug python=off petsc=off compiler=mpicxx solib
-                cp build/debug-nopetsc-nopython/libprecice.* ${FOAM_LIBBIN}/
-                rm -rf build/*
+                cd src/thirdParty && ./compile_precice
         - script:
             name: boundary conditions
             code: |
@@ -286,19 +262,7 @@ ubuntu:
             name: precice
             code: |
                 (cd /home/foam-extend-3.2 && source etc/prefs.sh && source etc/bashrc)
-
-                cd src/thirdParty
-
-                export PRECICE_MPI_LIB=mpi
-                export PRECICE_MPI_LIB_PATH="`mpicc --showme:libdirs`"
-                export PRECICE_MPI_INC_PATH="`mpicc --showme:incdirs`"
-                export CPLUS_INCLUDE_PATH=`pwd`/eigen:`pwd`/boost
-                export LIBRARY_PATH=$FOAM_LIBBIN
-
-                cd precice
-                scons -j $WM_NCOMPPROCS build=release python=off petsc=off compiler=mpicxx solib
-                cp build/release-nopetsc-nopython/libprecice.* ${FOAM_LIBBIN}/
-                rm -rf build/*
+                cd src/thirdParty && ./compile_precice
         - script:
             name: boundary conditions
             code: |


### PR DESCRIPTION
* Do not remove the previous build of elemental in order to speedup recompilation times
* Use the compilation script of `precice` during the `wercker` build