### PR TITLE
Bugfix RBF mesh motion solver: use rbf->initialized()

### DIFF
--- a/src/RBFMeshMotionSolver/AdaptiveCoarsening.C
+++ b/src/RBFMeshMotionSolver/AdaptiveCoarsening.C
@@ -18,7 +18,9 @@ namespace rbf
         reselectionTol( reselectionTol ),
         minPoints( minPoints ),
         maxPoints( maxPoints ),
-        rbf( new ElRBFInterpolation() )
+        rbf( new ElRBFInterpolation() ),
+        positions( new ElDistVector() ),
+        positionsInterpolation( new ElDistVector() )
     {
         assert( maxPoints >= minPoints );
         assert( tol > 0 );
@@ -172,7 +174,7 @@ namespace rbf
 
     bool AdaptiveCoarsening::initialized()
     {
-        return rbf->initialized();
+        return rbf->initialized() || positions->Height() > 0;
     }
 
     std::unique_ptr<ElDistVector> AdaptiveCoarsening::interpolate( const std::unique_ptr<ElDistVector> & values )

--- a/src/RBFMeshMotionSolver/ElRBFMeshMotionSolver.C
+++ b/src/RBFMeshMotionSolver/ElRBFMeshMotionSolver.C
@@ -233,7 +233,7 @@ void ElRBFMeshMotionSolver::solve()
 
     // If the points are already selected, the rbf.compute() is already
     // called.
-    if ( boundaryPoints.empty() )
+    if ( !rbf->initialized() )
     {
         forAll( staticPatchIDs, patchId )
         {


### PR DESCRIPTION
Use rbf::initialized() to determine whether the interpolation matrices should be updated. Otherwise a deadlock could occur when one core has zero boundary points.